### PR TITLE
Export IAM keys to secrents manager

### DIFF
--- a/modules/tf_admin/main.tf
+++ b/modules/tf_admin/main.tf
@@ -6,3 +6,19 @@ resource "aws_iam_user" "tf_admin" {
 resource "aws_iam_access_key" "tf_admin" {
   user = aws_iam_user.tf_admin.name
 }
+
+resource "aws_secretsmanager_secret" "tf_admin" {
+  name                    = "tf_admin/${var.username}"
+  recovery_window_in_days = 0
+  tags                    = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "version" {
+  secret_id = aws_secretsmanager_secret.tf_admin.id
+  secret_string = jsonencode(
+    {
+      "aws_access_key_id" : aws_iam_access_key.tf_admin.id
+      "aws_secret_access_key" : aws_iam_access_key.tf_admin.secret
+    }
+  )
+}


### PR DESCRIPTION
The IAM keys will be used as GitHub Action secrets.
We use AWS secrets manager to share the secret data.
