### PR TITLE
Change prefix in TF secrets names to _github_control__

### DIFF
--- a/modules/tf_admin/main.tf
+++ b/modules/tf_admin/main.tf
@@ -8,7 +8,7 @@ resource "aws_iam_access_key" "tf_admin" {
 }
 
 resource "aws_secretsmanager_secret" "tf_admin" {
-  name                    = "tf_admin/${var.username}"
+  name                    = "_github_control__tf_admin/${var.username}"
   recovery_window_in_days = 0
   tags                    = var.tags
 }


### PR DESCRIPTION
Why - because there is already an IAM policy that allows access to a
namespace. Let's use it!
